### PR TITLE
[jh] thread.c thread_sleep() 와 thread_awake() 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pintos Project 2: Alarm clock-design and implementation
-
+# 구현 전 backup-version
 ## 구현 목표
 
 - Pintos의 thread가 timer_sleep()을 호출하면, 지정된 tick 동안 sleep 상태로 전환되고, 해당 시간이 지나면 자동으로 깨어나도록 구현합니다.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pintos Project 2: Alarm clock-design and implementation
-# 구현 전 backup-version
+
 ## 구현 목표
 
 - Pintos의 thread가 timer_sleep()을 호출하면, 지정된 tick 동안 sleep 상태로 전환되고, 해당 시간이 지나면 자동으로 깨어나도록 구현합니다.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@
 
 5. **핵심 함수 구현**
    - `thread_sleep(int64_t wakeup_tick)`: 현재 thread를 sleep_list에 추가하고 BLOCKED 상태로 전환.
-   - `thread_awake(int64_t current_tick)`: sleep_list를 순회하며, 깨어날 시간이 된 thread를 READY 상태로 전환.
+   - `thread_awake(int64_t current_tick)`: sleep_list를 순회하며, 깨어날 시간이 된 thread를 READY 상태로 전환. 
 
 6. **그 외**
    - 동기화 및 race condition 방지를 위해 적절히 인터럽트를 disable/enable 합니다.
    - 테스트 통과를 위해 우선순위 스케줄링 등 추가 구현이 필요할 수 있습니다.
+   - 개발 과정은 timer.c 수정과 thread.c 및 thread.h 관련 수정으로 구분 

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -325,6 +325,37 @@ thread_sleep(int64_t ticks)
   intr_set_level(old_level);
 }
 
+void
+thread_awake(int64_t ticks)
+{
+  struct list_elem *e;
+  e = list_begin(&blocked_list);
+
+  while(e != list_end(&blocked_list))
+  {
+    struct thread *t = list_entry(e, struct thread, elem);
+
+    if(t->tick_to_awake <= ticks){
+      e = list_remove(e);
+      t->tick_to_awake = 0;
+
+      enum intr_level old_level;
+
+      ASSERT(is_thread(t));
+
+      old_level = intr_disable();
+      ASSERT(t->status == THREAD_BLOCKED);
+      list_push_back(&ready_list, &t->elem);
+      t->status = THREAD_READY;
+    }
+    else{
+      e = list_next(e);
+    }
+  }
+
+  update_next_tick_to_awake();
+}
+
 /* Yields the CPU.  The current thread is not put to sleep and
    may be scheduled again immediately at the scheduler's whim. */
 void

--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -301,6 +301,30 @@ thread_exit (void)
   NOT_REACHED ();
 }
 
+/**/
+void
+thread_sleep(int64_t ticks)
+{
+  struct thread *cur = thread_current();
+  enum intr_level old_level;
+
+  ASSERT(!intr_context());
+  
+  old_level = intr_disable();
+  if(cur != idle_thread)
+  {
+    cur->tick_to_awake = ticks;
+    list_push_back(&blocked_list, &cur->elem);
+  }
+  update_next_tick_to_awake();
+
+  cur->status = THREAD_BLOCKED;
+
+  schedule();
+
+  intr_set_level(old_level);
+}
+
 /* Yields the CPU.  The current thread is not put to sleep and
    may be scheduled again immediately at the scheduler's whim. */
 void


### PR DESCRIPTION
[jh] thread.c thread_sleep() 와 thread_awake() 구현

---

## 1. 작업 내용
- thread_sleep 구현 
    - 현재 쓰레드가 idle 쓰레드가 아닐 경우 cur 쓰레드의 tick to awake 값을 전달 받은 값으로 설정
    -  blocked list로 현재 쓰레드 push
    - cur 의 상태를 blocked으로 변경
    - 스케줄링 

- thread_awake 구현 
    - t->tick_to_awake <= ticks 의 경우 
    - blocked_list 맨 앞 요소를 리스트에서 제거 
    - ready list에 요소를 pushback
    - 맨 앞 쓰레드의 상태를 THREAD_READY 로 변경 
---

### 체크리스트
