### PR TITLE
fead:week2 update_next_tick_to_awake, get_next_tick_to_awake 구현

### DIFF
--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -584,7 +584,24 @@ allocate_tid (void)
 
   return tid;
 }
+
+void 
+update_next_tick_to_awake (void)
+{
+  if(list_empty(&blocked_list))
+    next_tick_to_awake = INT64_MAX;
+  else
+    {
+      struct thread *t = list_entry(list_front(&blocked_list), struct thread, elem);
+      next_tick_to_awake = t->tick_to_awake;
+    }
+}
 
+int64_t
+get_next_tick_to_awake (void)
+{
+  return list_empty(&blocked_list) ? INT64_MAX : next_tick_to_awake;
+}
 /* Offset of `stack' member within `struct thread'.
    Used by switch.S, which can't figure it out on its own. */
 uint32_t thread_stack_ofs = offsetof (struct thread, stack);


### PR DESCRIPTION
update_tick, get_tick 함수 구현

---

## 1. 작업 내용
- update_next_tick_ti_awake 함수 정의/
   - blocked_list가 비어있으면 next_tick_to_awake변수를 INT64_MAX로 초기화 아니라면 선형탐색으로 가장 작은 값을 탐색

- get_next_tick_to_awake 함수 정의/
   - next_tick_to_awake변수 반환, blocked_list가 비어있다면 INT64_MAX를 반환

## 체크리스트
- 이 기능을 사용하는 본인의 함수가 이 함수의 반환값과 같은 데이터 타입을 사용하는지 확인

